### PR TITLE
make format-xml to reformat, make hook to set up pre-commit hook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 export
 
+SHELL = bash
+
 # Language to build. Default: $(LANG)
 LANG = en
 
@@ -33,8 +35,10 @@ help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
-	@echo "    deps   Download DITA-OT dist"
-	@echo "    build  Build HTML"
+	@echo "    deps        Download DITA-OT dist"
+	@echo "    build       Build HTML"
+	@echo "    format-xml  Consistently indent XML"
+	@echo "    hook        Install git pre-commit hook"
 	@echo ""
 	@echo "  Variables"
 	@echo ""
@@ -64,3 +68,13 @@ build:
 		--args.input.dir="$(REPODIR)" \
 		--propertyfile="$(DITA_PROPERTY_FILE)"
 	cp -r $(REPODIR)/resources/ $(GT_DOC_OUT)
+
+# Consistently indent XML
+format-xml:
+	find . -path ./$(notdir $(DITA_OT_DIR)) -prune -false -o -name '*.dita' -a -not \( -size 0 \) |while read i;do \
+		echo xmlstarlet fo $$i > $$i.formatted && mv $$i.formatted $$i; \
+	done
+
+# Install git pre-commit hook
+hook:
+	cp dev/pre-commit `git rev-parse --git-path hooks`

--- a/dev/pre-commit
+++ b/dev/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+make format-xml
+git add en de
+git status --porcelain|grep -qP '^M.*dita$'
+if (( $?  == 0 ));then
+    echo "XML needed reformatting, please run 'git commit' again"
+    exit 1
+fi


### PR DESCRIPTION
With `make format-xml` all the DITA files are reformatted using `xmlstarlet fo`, much like @bertsky did in #20.

`make hook` installs a pre-commit hook that:

* runs `make format-xml`
* checks whether any reformatted XML files need to be committed
* aborts the commit if that is the case - just call `git commit` again and the changed files will be added.

I actually had to disable the hook for this PR ;-)